### PR TITLE
fix invalid resource name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 WORKDIR /tmp/build
 
 ENV runDependencies curl jq bash
-ENV kubectlURL https://storage.googleapis.com/kubernetes-release/release/v1.5.3/bin/linux/amd64/kubectl
+ENV kubectlURL https://storage.googleapis.com/kubernetes-release/release/v1.8.3/bin/linux/amd64/kubectl
 
 RUN apk --no-cache add ${runDependencies}; \
     curl -L -o /usr/local/bin/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 WORKDIR /tmp/build
 
 ENV runDependencies curl jq bash
-ENV kubectlURL https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubectl
+ENV kubectlURL https://storage.googleapis.com/kubernetes-release/release/v1.5.3/bin/linux/amd64/kubectl
 
 RUN apk --no-cache add ${runDependencies}; \
     curl -L -o /usr/local/bin/kubectl \

--- a/bin/out
+++ b/bin/out
@@ -26,7 +26,7 @@ rollingupdate() {
     [ -n "$RC" ] || exit 1
     [ -n "$IMAGE" ] || exit 1
 
-    $KUBECTL rolling-update "rc/$RC" --image="$IMAGE"
+    $KUBECTL rolling-update --image=$IMAGE $RC 
 }
 
 start_job() {

--- a/bin/out
+++ b/bin/out
@@ -26,7 +26,7 @@ rollingupdate() {
     [ -n "$RC" ] || exit 1
     [ -n "$IMAGE" ] || exit 1
 
-    $KUBECTL rolling-update --image=$IMAGE $RC 
+    $KUBECTL rolling-update --image=$IMAGE $RC --image-pull-policy Always
 }
 
 start_job() {


### PR DESCRIPTION
I'm getting `error: invalid resource name "rc/asp-ct-controller-v1": [may not contain '/']` on both kubernetes 1.4 and 1.5.

<img width="999" alt="screen shot 2017-02-13 at 9 07 39 am" src="https://cloud.githubusercontent.com/assets/110999/22894480/f96b170e-f1cd-11e6-8f05-d320dd139c94.png">

`rolling-update` works for me when I remove the `rc/` and put just the RC name.

<img width="1006" alt="screen shot 2017-02-13 at 9 25 40 am" src="https://cloud.githubusercontent.com/assets/110999/22894605/7ded1a5e-f1ce-11e6-95a3-df5c2c4773cd.png">

This PR might not be acceptable as-is since I haven't tested to make sure <1.4 versions work.

btw, thanks for this resource!